### PR TITLE
Changed ArquillianSuiteExtension to determine if being run in a Suite.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
         
@@ -173,6 +172,37 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                	<groupId>org.eclipse.m2e</groupId>
+                	<artifactId>lifecycle-mapping</artifactId>
+                	<version>1.0.0</version>
+                	<configuration>
+                		<lifecycleMappingMetadata>
+                			<pluginExecutions>
+                				<pluginExecution>
+                					<pluginExecutionFilter>
+                						<groupId>
+                							org.apache.maven.plugins
+                						</groupId>
+                						<artifactId>
+                							maven-war-plugin
+                						</artifactId>
+                						<versionRange>
+                							[2.4,)
+                						</versionRange>
+                						<goals>
+                							<goal>exploded</goal>
+                						</goals>
+                					</pluginExecutionFilter>
+                					<action>
+                						<ignore></ignore>
+                					</action>
+                				</pluginExecution>
+                			</pluginExecutions>
+                		</lifecycleMappingMetadata>
+                	</configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
We wanted to be able to run single test with a smaller deployment
defined only for that test.  This change then will use @Deploymnet
defined in the test when not part of suite, and if being run as part
of a suite it will then look for @ArquillianSuiteDeployment for
deployments.

Any test that provides it's own @Deployment should not extend
@ArquillianSuiteDeployment since that will cause an error when
run as part of a suite.

Probably not the best way to implement this, but I like the idea of not
having to deploy my entire app when working on a bug in a single test.