### PR TITLE
Bug? Duplicated class annotated with ArquillianS..

### DIFF
--- a/src/main/java/org/eu/ingwar/tools/arquillian/extension/suite/ArquillianSuiteExtension.java
+++ b/src/main/java/org/eu/ingwar/tools/arquillian/extension/suite/ArquillianSuiteExtension.java
@@ -44,6 +44,7 @@ import java.util.logging.Logger;
 import org.jboss.arquillian.core.impl.ManagerImpl;
 import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 import org.reflections.Reflections;
+import org.reflections.util.ClasspathHelper;
 
 /**
  * Arquillian Suite Extension main class.

--- a/src/main/java/org/eu/ingwar/tools/arquillian/extension/suite/ArquillianSuiteExtension.java
+++ b/src/main/java/org/eu/ingwar/tools/arquillian/extension/suite/ArquillianSuiteExtension.java
@@ -75,19 +75,27 @@ public class ArquillianSuiteExtension implements LoadableExtension {
      * @ArquillianSuiteDeployment annotation
      */
     private static Class<?> getDeploymentClass() {
-        // Reflection all classes to search for Annotation @ArquillianSuiteDeployment.
-        final Set<Class<?>> results = new Reflections("").getTypesAnnotatedWith(ArquillianSuiteDeployment.class, true);
         // Had a bug that if you open inside eclipse more than one project with @ArquillianSuiteDeployment and is a dependency, the test doesn't run because found more than one @ArquillianSuiteDeployment.
         // Filter the deployment PER project.
-        final Reflections reflections = new Reflections(Thread.currentThread().getContextClassLoader().getResource(""));
-        for (final Class<?> clazz : results) {
-            // Just verify if the class is the class that your project is looking for.
-            if (!reflections.getSubTypesOf(clazz).isEmpty()) {
-                // Return the correct Class.
-                return clazz;
-            }
-        }
-        return null;
+        final Reflections reflections = new Reflections(ClasspathHelper.contextClassLoader().getResource(""));
+        // Reflection all classes to search for Annotation @ArquillianSuiteDeployment.
+		Set<Class<?>> results = reflections.getTypesAnnotatedWith(ArquillianSuiteDeployment.class, true);
+		if (results.isEmpty()) {
+		    // Keeping compatibility backward.
+			results = reflections.getTypesAnnotatedWith(ArquilianSuiteDeployment.class, true);
+			if (results.isEmpty()) {
+				return null;
+			}
+		}
+		// Verify if has more than one @ArquillianSuiteDeployment.
+		if (results.size() > 1) {
+			for (final Class<?> type : results) {
+				log.log(Level.SEVERE, "arquillian-suite-deployment: Duplicated class annotated with @ArquillianSuiteDeployment: {0}", type.getName());
+			}
+			throw new IllegalStateException("Duplicated classess annotated with @ArquillianSuiteDeployment");
+		}
+		// Return the single result.
+		return results.iterator().next();
     }
 
     /**


### PR DESCRIPTION
Hello, Ingwar!

Is Duplicated class annotated with @ArquillianSuiteDeployment a bug?
Fixing a bug when inside eclipse you open two or more projects that are dependency with other and it shows that the @ArquillianSuiteDeployment is duplicated. Maybe it happens on maven test also.
Example, can be project or module:
Project A
Project B
Project A - Has a Test Class ExampleProjectATestSuite with @ArquillianSuiteDeployment and @Deployment
Project A - Has Test Classes extending ExampleProjectATestSuite
Project B - Depends on Project A
Project B - Has your own Test Class ExampleProjectBTestSuite with @ArquillianSuiteDeployment and @Deployment 
Project B - Has Test Classes extending ExampleProjectBTestSuite
Project A - mvn test or run test inside eclipse
Project A - SUCCESS;
Project B - mvn test or run test inside eclipse.
Project B - SEVERE ERROR: log.log(Level.SEVERE, "arquillian-suite-deployment: Duplicated class annotated with @ArquillianSuiteDeployment: {0}", type.getName());

Is it normal? Because using that code that I'm pushing solved my problem and my projects runs smoothly and at light speed.

I found another problem that when the application is undeploying, but not the datasource, when the second project is running, says that the datasource already exists. But it can be another change, I'll search something.
If it's not the right place to commit, sorry, just say to me where I should commit.

Thank you!