### PR TITLE
Allow to configure for full classpath scan.

### DIFF
--- a/src/main/java/org/eu/ingwar/tools/arquillian/extension/suite/DeploymentClassFinder.java
+++ b/src/main/java/org/eu/ingwar/tools/arquillian/extension/suite/DeploymentClassFinder.java
@@ -59,9 +59,9 @@ class DeploymentClassFinder {
      */
     private static Class<?> getDeploymentClassFromAnnotation(ArquillianDescriptor descriptor) {
     	final Reflections reflections;
-    	if (isUseFullClassPathFromXml(descriptor)) {
+    	if (shouldScanFullClasspath(descriptor)) {
     		// Clients can opt-in to search on the full classpath. 
-    		reflections = new Reflections(ClasspathHelper.forClassLoader());
+    		reflections = new Reflections(ClasspathHelper.contextClassLoader());
     	} else {
 		    // Had a bug that if you open inside eclipse more than one project with @ArquillianSuiteDeployment and is a dependency, the test doesn't run because found more than one @ArquillianSuiteDeployment.
 		    // Filter the deployment PER project.
@@ -86,14 +86,14 @@ class DeploymentClassFinder {
     }
     
     /**
-     * Returns name of class witch should be used as global deployment.
+     * Indicates if the deployment annotated class should be searched across the whole available classpath.
      * Extension name used: suite
-     * Key: deploymentClass
+     * Key: fullClasspathScan
      *
      * @param descriptor ArquillianDescriptor
-     * @return full class name from arquillian.xml
+     * @return flag value from arquillian.xml
      */
-    private static boolean isUseFullClassPathFromXml(ArquillianDescriptor descriptor) {
+    private static boolean shouldScanFullClasspath(ArquillianDescriptor descriptor) {
         ExtensionDef extension = descriptor.extension("suite");
         if (extension != null) {
             String fullClasspathScan = extension.getExtensionProperties().get("fullClasspathScan");

--- a/src/main/java/org/eu/ingwar/tools/arquillian/extension/suite/DeploymentClassFinder.java
+++ b/src/main/java/org/eu/ingwar/tools/arquillian/extension/suite/DeploymentClassFinder.java
@@ -60,8 +60,14 @@ class DeploymentClassFinder {
     private static Class<?> getDeploymentClassFromAnnotation(ArquillianDescriptor descriptor) {
     	final Reflections reflections;
     	if (shouldScanFullClasspath(descriptor)) {
-    		// Clients can opt-in to search on the full classpath. 
-    		reflections = new Reflections(ClasspathHelper.contextClassLoader());
+    		// Clients can opt-in to search on the full classpath.
+    		// In some setups (such as when running tests through maven surefire plugin)
+    		// the classloader doesn't give access to the full classpath.
+			// When the classpath is loaded though a "booter jar" (which contain the actual
+			// classpath as manifest attribute) we can still access the fully loaded java
+			// classpath dynamically, that we give as second argument here.
+    		// Note that this may not be sufficient in some setups ; this is a best effort.
+    		reflections = new Reflections(ClasspathHelper.contextClassLoader(), ClasspathHelper.forJavaClassPath());
     	} else {
 		    // Had a bug that if you open inside eclipse more than one project with @ArquillianSuiteDeployment and is a dependency, the test doesn't run because found more than one @ArquillianSuiteDeployment.
 		    // Filter the deployment PER project.

--- a/src/test/java/org/eu/ingwar/tools/arquillian/extension/suite/DeploymentClassFinderTest.java
+++ b/src/test/java/org/eu/ingwar/tools/arquillian/extension/suite/DeploymentClassFinderTest.java
@@ -1,0 +1,334 @@
+package org.eu.ingwar.tools.arquillian.extension.suite;
+
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.descriptor.api.ContainerDef;
+import org.jboss.arquillian.config.descriptor.api.DefaultProtocolDef;
+import org.jboss.arquillian.config.descriptor.api.EngineDef;
+import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
+import org.jboss.arquillian.config.descriptor.api.GroupDef;
+import org.jboss.shrinkwrap.descriptor.api.DescriptorExportException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests different ways of loading the deployment class using
+ * {@link DeploymentClassFinder#getDeploymentClass(ArquillianDescriptor)}.
+ * 
+ * @author Stephane Wasserhardt
+ */
+public class DeploymentClassFinderTest {
+
+	/**
+	 * Contructor.
+	 */
+	public DeploymentClassFinderTest() {
+	}
+
+	/**
+	 * Makes the current context class loader not able to find the deployment class,
+	 * while running the provided test runnable.
+	 * 
+	 * @param test Test {@link Runnable} to run.
+	 */
+	private void runUsingMockedContextClassLoader(Runnable test) {
+		ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+		// Simulate the use of a classloader that don't reference the class annotated
+		// with @ArquillianSuiteDeployment.
+		try {
+			Thread.currentThread().setContextClassLoader(new TestClassLoader(contextClassLoader));
+
+			test.run();
+
+		} finally {
+			Thread.currentThread().setContextClassLoader(contextClassLoader);
+		}
+	}
+
+	/**
+	 * The {@link Deployments} class is annotated with
+	 * {@link ArquillianSuiteExtension}, this test asserts that it is found by the
+	 * default implementation of
+	 * {@link DeploymentClassFinder#getDeploymentClass(ArquillianDescriptor)}.
+	 */
+	@Test
+	public void testCanFindDeploymentUsingContextClassloader() {
+		final ArquillianDescriptor descriptorMock = new ArquillianDescriptorMock();
+
+		Class<?> deploymentClass = DeploymentClassFinder.getDeploymentClass(descriptorMock);
+		Assert.assertEquals(Deployments.class, deploymentClass);
+	}
+
+	/**
+	 * On the contrary to {@link #testCanFindDeploymentUsingContextClassloader()},
+	 * if we use a Classloader that can't load the {@link Deployments} class, this
+	 * test asserts that the default implementation of
+	 * {@link DeploymentClassFinder#getDeploymentClass(ArquillianDescriptor)} will
+	 * not be able to find the class.
+	 */
+	@Test
+	public void testCannotFindDeploymentUsingWrongClassloader() {
+		final ArquillianDescriptor descriptorMock = new ArquillianDescriptorMock();
+
+		Runnable test = new Runnable() {
+			@Override
+			public void run() {
+				Class<?> deploymentClass = DeploymentClassFinder.getDeploymentClass(descriptorMock);
+				Assert.assertNull(deploymentClass);
+			}
+		};
+
+		runUsingMockedContextClassLoader(test);
+	}
+
+	/**
+	 * As in {@link #testCannotFindDeploymentUsingWrongClassloader()}, the
+	 * {@link Deployments} class will not be found by the default scanning
+	 * implementation of
+	 * {@link DeploymentClassFinder#getDeploymentClass(ArquillianDescriptor)}. This
+	 * time, we also explicitly give the class name, so that we don't use scanning
+	 * for the {@link ArquillianSuiteExtension} annotation. We test the
+	 * {@link Deployments} class is then found by
+	 * {@link DeploymentClassFinder#getDeploymentClass(ArquillianDescriptor)}.
+	 */
+	@Test
+	public void testFindDeploymentFromConfigUsingExplicitClass() {
+		final ArquillianDescriptor descriptorMock = new ArquillianDescriptorMock("deploymentClass",
+				Deployments.class.getName());
+
+		Runnable test = new Runnable() {
+			@Override
+			public void run() {
+				Class<?> deploymentClass = DeploymentClassFinder.getDeploymentClass(descriptorMock);
+				Assert.assertEquals(Deployments.class, deploymentClass);
+			}
+		};
+
+		runUsingMockedContextClassLoader(test);
+	}
+
+	/**
+	 * As in {@link #testCannotFindDeploymentUsingWrongClassloader()}, the
+	 * {@link Deployments} class will not be found by the default scanning
+	 * implementation of
+	 * {@link DeploymentClassFinder#getDeploymentClass(ArquillianDescriptor)}. This
+	 * time, we specify full classpath scanning. We test the {@link Deployments}
+	 * class is then found by
+	 * {@link DeploymentClassFinder#getDeploymentClass(ArquillianDescriptor)}.
+	 */
+	@Test
+	public void testFindDeploymentFromAnnotationUsingFullClasspathScan() {
+		final ArquillianDescriptor descriptorMock = new ArquillianDescriptorMock("fullClasspathScan",
+				Boolean.TRUE.toString());
+
+		Runnable test = new Runnable() {
+			@Override
+			public void run() {
+				Class<?> deploymentClass = DeploymentClassFinder.getDeploymentClass(descriptorMock);
+				Assert.assertEquals(Deployments.class, deploymentClass);
+			}
+		};
+
+		runUsingMockedContextClassLoader(test);
+	}
+
+	/**
+	 * A ClassLoader which is never able to load any class.
+	 * 
+	 * @author Stephane Wasserhardt
+	 */
+	private static class TestClassLoader extends URLClassLoader {
+		public TestClassLoader(ClassLoader contextClassLoader) {
+			super(((URLClassLoader) contextClassLoader).getURLs());
+		}
+		
+		@Override
+		public URL getResource(String name) {
+			if ("".equals(name)) {
+				// We end-up in this case when we do not use full classpath scanning.
+				// We test the case where we obtain a valid classpath entry, but one which does not contain the annotated class.
+				// This way, we must do a full classpath scan to find the annotated class.
+				URL resource = super.getResource("META-INF");
+				return resource;
+			}
+			return super.getResource(name);
+		}
+	}
+
+	/**
+	 * Mocks ArquillianDescriptor for {@link DeploymentClassFinderTest} use-cases.
+	 * 
+	 * @author Stephane Wasserhardt
+	 */
+	private static class ArquillianDescriptorMock implements ArquillianDescriptor {
+
+		private final Map<String, String> props;
+
+		public ArquillianDescriptorMock() {
+			props = new HashMap<String, String>();
+		}
+
+		public ArquillianDescriptorMock(String key, String value) {
+			props = new HashMap<String, String>();
+			props.put(key, value);
+		}
+
+		@Override
+		public String getDescriptorName() {
+			return null;
+		}
+
+		@Override
+		public String exportAsString() throws DescriptorExportException {
+			return null;
+		}
+
+		@Override
+		public void exportTo(OutputStream output) throws DescriptorExportException, IllegalArgumentException {
+		}
+
+		@Override
+		public EngineDef engine() {
+			return null;
+		}
+
+		@Override
+		public DefaultProtocolDef defaultProtocol(String type) {
+			return null;
+		}
+
+		@Override
+		public DefaultProtocolDef getDefaultProtocol() {
+			return null;
+		}
+
+		@Override
+		public ContainerDef container(String name) {
+			return null;
+		}
+
+		@Override
+		public GroupDef group(String name) {
+			return null;
+		}
+
+		@Override
+		public ExtensionDef extension(String name) {
+			if ("suite".equals(name)) {
+				return new ExtensionDefMock();
+			}
+			return null;
+		}
+
+		@Override
+		public List<ContainerDef> getContainers() {
+			return null;
+		}
+
+		@Override
+		public List<GroupDef> getGroups() {
+			return null;
+		}
+
+		@Override
+		public List<ExtensionDef> getExtensions() {
+			return null;
+		}
+
+		private class ExtensionDefMock implements ExtensionDef {
+
+			@Override
+			public EngineDef engine() {
+				return null;
+			}
+
+			@Override
+			public DefaultProtocolDef defaultProtocol(String type) {
+				return null;
+			}
+
+			@Override
+			public DefaultProtocolDef getDefaultProtocol() {
+				return null;
+			}
+
+			@Override
+			public ContainerDef container(String name) {
+				return null;
+			}
+
+			@Override
+			public GroupDef group(String name) {
+				return null;
+			}
+
+			@Override
+			public ExtensionDef extension(String name) {
+				return null;
+			}
+
+			@Override
+			public List<ContainerDef> getContainers() {
+				return null;
+			}
+
+			@Override
+			public List<GroupDef> getGroups() {
+				return null;
+			}
+
+			@Override
+			public List<ExtensionDef> getExtensions() {
+				return null;
+			}
+
+			@Override
+			public String getDescriptorName() {
+				return null;
+			}
+
+			@Override
+			public String exportAsString() throws DescriptorExportException {
+				return null;
+			}
+
+			@Override
+			public void exportTo(OutputStream output) throws DescriptorExportException, IllegalArgumentException {
+			}
+
+			@Override
+			public String getExtensionName() {
+				return null;
+			}
+
+			@Override
+			public ExtensionDef setExtensionName(String name) {
+				return null;
+			}
+
+			@Override
+			public ExtensionDef property(String name, String value) {
+				return null;
+			}
+
+			@Override
+			public Map<String, String> getExtensionProperties() {
+				return props;
+			}
+
+			@Override
+			public String getExtensionProperty(String name) {
+				return props.get(name);
+			}
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
Clients can configure the extension in order for the annotated class
search process to scan the full classpath.